### PR TITLE
Base geocoding system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,9 @@ gem "dry-transaction"
 gem "dry-types"
 gem "dry-validation"
 gem "dry-view"
-gem "down"
-gem "slim"
+gem "down", "~> 4.6"
+gem "slim", "~> 4.0"
+gem "typhoeus", "~> 1.3"
 
 group :development, :test do
   gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     dotenv (0.7.0)
-    down (4.6.0)
+    down (4.6.1)
       addressable (~> 2.5)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
@@ -182,6 +182,8 @@ GEM
     dry-web (0.8.0)
       dry-monitor (~> 0.1)
       dry-system (~> 0.9)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     ffi (1.9.25)
     foreman (0.64.0)
       dotenv (~> 0.7.0)
@@ -272,6 +274,8 @@ GEM
     thor (0.20.0)
     tilt (2.0.8)
     transproc (1.0.2)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -284,7 +288,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   capybara-screenshot
-  down
+  down (~> 4.6)
   dry-auto_inject!
   dry-matcher
   dry-monads
@@ -312,8 +316,9 @@ DEPENDENCIES
   rom-sql!
   rspec
   sequel_pg
-  slim
+  slim (~> 4.0)
   snowflakes!
+  typhoeus (~> 1.3)
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/lib/decaf_sucks/geocoding/providers/nominatim/geocoder.rb
+++ b/lib/decaf_sucks/geocoding/providers/nominatim/geocoder.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+# auto_register: false
+
+require "typhoeus"
+require "json"
+require "decaf_sucks/geocoding/result"
+
+module DecafSucks
+  module Geocoding
+    module Providers
+      module Nominatim
+        class Geocoder
+          BASE_URL = "https://nominatim.openstreetmap.org/"
+          DEFAULT_PARAMS = {format: "json"}.freeze
+
+          SEARCH_URL = "#{BASE_URL}/search"
+          SEARCH_PARAMS = DEFAULT_PARAMS.merge(addressdetails: 1).freeze
+
+          def search(q:)
+            response = Typhoeus.get(SEARCH_URL, params: SEARCH_PARAMS.merge(q: q))
+
+            JSON.parse(response.body, symbolize_names: true).map { |result| Result.new(result) }
+          end
+
+          REVERSE_URL = "#{BASE_URL}/reverse"
+          REVERSE_PARAMS = DEFAULT_PARAMS.merge(addressdetails: 1).freeze
+
+          def reverse(lat:, lon:)
+            response = Typhoeus.get(REVERSE_URL, params: REVERSE_PARAMS.merge(lat: lat, lon: lon))
+
+            Result.new(JSON.parse(response.body, symbolize_names: true))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/decaf_sucks/geocoding/result.rb
+++ b/lib/decaf_sucks/geocoding/result.rb
@@ -1,0 +1,22 @@
+# auto_register: false
+
+require "decaf_sucks/types"
+
+module DecafSucks
+  module Geocoding
+    class Result < Dry::Struct
+      attribute :lat, Types::Strict::String
+      attribute :lon, Types::Strict::String
+      attribute :display_name, Types::Strict::String
+      attribute :address do
+        attribute :road, Types::Strict::String
+        attribute :suburb, Types::Strict::String
+        attribute :city, Types::Strict::String
+        attribute :state, Types::Strict::String
+        attribute :postcode, Types::Strict::String
+        attribute :country, Types::Strict::String
+        attribute :country_code, Types::Strict::String
+      end
+    end
+  end
+end

--- a/system/boot/geocoder.rb
+++ b/system/boot/geocoder.rb
@@ -1,0 +1,7 @@
+DecafSucks::Container.boot :geocoder do
+  start do
+    require "decaf_sucks/geocoding/providers/nominatim/geocoder"
+
+    register :geocoder, DecafSucks::Geocoding::Providers::Nominatim::Geocoder.new
+  end
+end


### PR DESCRIPTION
Add a multi-provider Geocoding backend for the app. The intention here is to add a common abstraction over the providers, and make it easy to switch between them, so that we're not ever cripplingly tied to a single one.

- [ ] Initial provider ([OSM Nominatim](https://wiki.openstreetmap.org/wiki/Nominatim))
- [ ] Integration tests for initial provider with HTTP request mocking
- [ ] Secondary provider (maybe [LocationIQ](https://locationiq.com/))
- [ ] Redis-based caching layer for geocoding requests